### PR TITLE
test: Java 11 以上でもテストが通るようにプロファイルを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,16 @@
         <junit.additionalArgLine>--add-modules java.xml.bind</junit.additionalArgLine>
       </properties>
     </profile>
+    <profile>
+      <id>java11</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun.activation</groupId>
+          <artifactId>javax.activation</artifactId>
+          <version>1.2.0</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <dependencies>


### PR DESCRIPTION
`javax.activation` が無いことで Java 11 のテストがエラーになっていたので、 Java 11 プロファイルを追加して `javax.activation` を依存関係に設定。